### PR TITLE
docs(readme): fix ROADMAP link broken by #26 declutter

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,7 +402,7 @@ The tribunal follows a four-sprint development plan toward v1.0.0:
 
 **Future backlog** includes: plugin architecture, REST API (FastAPI), collaborative features, export bridges (Obsidian, Notion, Zotero, Anki), interactive web UI, and semantic search with RAG.
 
-The full roadmap is maintained in [ROADMAP.md](./ROADMAP.md).
+The full roadmap is maintained in [ROADMAP.md](./docs/ROADMAP.md).
 
 ---
 


### PR DESCRIPTION
## What

The `Declutter root per #26` commit moved `ROADMAP.md` into `docs/` but left the README link in the Roadmap section pointing at `./ROADMAP.md` — a 404 on GitHub `main`. Repointed to `./docs/ROADMAP.md`.

Checked and clean: the `Installation`/`Usage` code blocks reference no moved docs (no `cp`-path regression), and links to `CONTRIBUTING.md`, `LICENSE`, `docs/GOVERNANCE.md` already resolve correctly.

## Impact

Markdown-only. No build/test impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)